### PR TITLE
Some edits for Preface.

### DIFF
--- a/book/pamphlet.tex
+++ b/book/pamphlet.tex
@@ -96,8 +96,8 @@ the machine was designed by a computer program, and so on, this causal
 chain eventually has its author.} and the author's motivations.
 
 Having worked for a couple of months in an engineering company that
-manufactured electronic equipment, I decided that perhaps its the
-best time to finish my education. I enrolled to the department of
+manufactured electronic equipment, I decided that perhaps it was the
+best time to finish my education. So, I enrolled at the department of
 Computer Science at the University of Gdańsk. Among other topics,
 one lab was devoted to data processing heuristics jointly named 
 ``computational intelligence''.
@@ -148,9 +148,9 @@ However, the case of the R programming language is particularly
 interesting, because initially it was just a harmless implementation
 of Scheme; but then as a result of the irresponsible experiments
 of mad scientists it mutated into a monster\cite{Ihaka2010}.}.
-The ultimate goal of this text is to kill them all.
+The ultimate goal of this text is to eliminate them all.
 
-Recognizing that the aforementioned goal is rather quixotic, I will be satisfied if anyone finds goodness in
+Recognizing that the aforementioned goal is rather quixotic, I will be satisfied instead if anyone finds any value in
 this pamphlet, whether it be education, entertainment or personal
 hygiene\footnote{Concerns the printed copies}.
 
@@ -219,8 +219,10 @@ during the execution of a program.
 In the case of math textbooks, exercises and examples
 are a way of facilitating comprehension. It is usually
 much easier to understand an abstract definition if
-we can train on examples, while exercises
-are ``partial examples'' making us come up with the
+we consider examples that are concrete instances of the abstract
+definition.  Similarly, exercises are like examples but where some or
+all of the reasoning is left out; as such, they can be thought of as
+``partial examples'' where we are challenged to come up with the
 reasoning for ourselves.
 
 Reading a math textbook without doing the exercises is also
@@ -234,8 +236,8 @@ purpose of ``doing their job'', rather than
 being comprehended and modified.
 
 From my experience, this approach dominates,
-not only in the industry (which is understandable),
-but also in education (which is harmful to the
+not only in industry (which is understandable),
+but also in education (which is harmful to
 industry).
 }.
 
@@ -260,7 +262,7 @@ succeed, thereby forcing generations of programmers to
 suffer due to the ignorance of their creators.
 
 However, as previously indicated, this book is about programming \textit{and} clear thinking in equal measure, and
-it is difficult to imagine someone that could not
+it is difficult to imagine someone who could not
 benefit from this combination.
 
 And so perhaps the shortest answer to the question posited
@@ -272,8 +274,8 @@ and encouraged me to devote time to this project.
 His classes were the source of all the examples presented in this text.
 
 I am also truly grateful to my family and my girlfriend,
-as they all encouraged me to go back to college. I certainly
-wouldn't make it without their support.
+as they all encouraged me to go back to university. I certainly
+couldn't have done it without their support.
 
 I deeply appreciate the interest, support, feedback and
 encouragement of my friends who allowed me to bother them with
@@ -287,10 +289,11 @@ for pointing out some errors and suggesting improvements.
 
 \section*{Reporting bugs}
 
-I realize that the quality of this text may be questionable.
-After all, this is a pamphlet. However, if you find any parts
-of the text obscure or difficult to understand, or if you
-find any mistakes in the explanations presented here, or
+Ah, bugs.  Perhaps, they can never be avoided (says your author
+wistfully and with a dramatic pause).
+
+If you find any mistakes in the explanations presented here, or if you
+find any parts of the text obscure or difficult to understand or
 simply want to talk about how miserable the world is, feel
 free to write an e-mail to
 \href{mailto:godek.maciek+pamphlet@gmail.com}{godek.maciek+pamphlet@gmail.com}.
@@ -300,7 +303,7 @@ of this pamphlet, always available from
 
 \url{https://panicz.github.io/pamphlet}
 
-as many of the bugs may already have been fixed.
+\noindent as many of the bugs may already have been fixed.
 
 %%%%%%%%%%%%%%%%
 % NEW CHAPTER! %


### PR DESCRIPTION
Details.
- s/enroll to/enroll at/
- s/kill/eliminate/
- s/goodness/any value/
  
  You originally had "any value" which is better IMO.  Also, just
  "value" would work.
- Re-worked "examples and exercises" part.
- s/in the industry/in industry/
- s/that/who/ (where it pertains to people)
- s/to college/to university/
  
  You originally had "to the university", but prefer "to university"
  (i.e no "the").
- In section "Reporting bugs", re-worked the "the quality of this text
  may be questionable" part.  Most English-speaking people use the
  word "questionable" usually to mean something like "spurious in
  nature" and I don't think you wanted/meant that. :)
  
  For instance, the first entry for the word "questionable" in the
  Random House Dictionary is "of doubtful propriety, honesty,
  morality, respectability, etc."
  (http://dictionary.reference.com/browse/questionable)
- Other small changes.
